### PR TITLE
Remove non-essential dependency with requires higher ruby verson than…

### DIFF
--- a/wraith.gemspec
+++ b/wraith.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'rake'
   spec.add_runtime_dependency 'image_size'
-  spec.add_runtime_dependency 'anemone'
   spec.add_runtime_dependency 'robotex'
   spec.add_runtime_dependency 'log4r'
   spec.add_runtime_dependency 'thor'


### PR DESCRIPTION
… we have

As long as we don't use the spidering functionality, we should be fine...